### PR TITLE
Duplicate render fix

### DIFF
--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -369,8 +369,7 @@ export default class MasonryList extends React.PureComponent {
 											_sortedData: sortedData
 										};
 									});
-								}
-								else {
+								} else {
 									const sortedData = insertIntoColumn(finalizedData, [], sorted);
 									this._calculatedData = [finalizedData];
 									this.renderIndex++;


### PR DESCRIPTION
This change fixes a bug where `images` are being rendered twice. This was due to `resolveImages()` being called twice by `componentWillReceiveProps()` with identical images data