### PR TITLE
Adding support for a FlatList header

### DIFF
--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -617,7 +617,8 @@ export default class MasonryList extends React.PureComponent {
 				}}
 				contentContainerStyle={[{
 					flexDirection: "row",
-					width: "100%"
+					width: "100%",
+					paddingTop: this.state._headerComponentHeight,
 				}, this.props.listContainerStyle]}
 				removeClippedSubviews={true}
 				onEndReachedThreshold={this.props.onEndReachedThreshold}
@@ -635,7 +636,7 @@ export default class MasonryList extends React.PureComponent {
 				}}
 				ListHeaderComponent={ () => this._renderListHeader() }
 				ListHeaderComponentStyle={{
-					top: -this.state._headerComponentHeight,
+					top: 0,
 					position:'absolute',
 					width:'100%'
 				}}

--- a/src/MasonryList.js
+++ b/src/MasonryList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FlatList, InteractionManager } from "react-native";
+import { FlatList, InteractionManager, View } from "react-native";
 import PropTypes from "prop-types";
 
 import { resolveImage, resolveLocal } from "./lib/model";

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ class Masonry extends React.PureComponent {
         backgroundColor: PropTypes.string,
         imageContainerStyle: PropTypes.object,
         listContainerStyle: PropTypes.object,
+	
+	ListHeaderComponent: PropTypes.node,
+	    
         renderIndividualHeader: PropTypes.oneOfType([
             PropTypes.func,
             PropTypes.node
@@ -216,6 +219,8 @@ class Masonry extends React.PureComponent {
                     //     this.props.masonryListRef &&
                     //         this.props.masonryListRef(component);
                     // }}
+
+		    ListHeaderComponent={this.props.ListHeaderComponent}
 
                     images={this.props.images}
                     columns={this.props.columns}


### PR DESCRIPTION
I'm using onLayout to adjust the absolute positioning of whatever component is passed in as the header to get around the flexDirection: 'row' styling in the FlatList needed to keep the columns organized. 